### PR TITLE
#61 amends to ignore changes to redirect uris from app registrations

### DIFF
--- a/azure/modules/entra-id-app-registration/main.tf
+++ b/azure/modules/entra-id-app-registration/main.tf
@@ -57,6 +57,10 @@ resource "azuread_application" "main" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [ web.0.redirect_uris ]
+  }
+
   optional_claims {
     id_token {
       name = "groups"


### PR DESCRIPTION
Ignore changes to redirect uris from app registrations, allowing developers/administrators to add additional redirect uri's for additional environments on the same cluster